### PR TITLE
add IMGT pull for TCE; update package specifications

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,10 +5,11 @@ flask-restplus==0.13.0
 behave==1.2.6
 PyHamcrest==1.9.0
 allure-behave==2.8.5
+itsdangerous==2.0.1
 matplotlib==3.1.3
 mpmath==1.1.0
 numpy==1.18.1
-pandas==1.0.1
+pandas>=1.1.4
 requests==2.22.0
 seaborn==0.10.0
 toolz==0.11.1


### PR DESCRIPTION
As discovered by @mmaiers-nmdp, some newer alleles do not have TCE groups with the current codebase. This update pulls the latest IMGT alleles directly.
```
Check the DPB1*688:01 allele. The TCE group is unable to be determined.
Check the DPB1*727:01 allele. The TCE group is unable to be determined.
Check the DPB1*760:01 allele. The TCE group is unable to be determined.
Check the DPB1*879:01 allele. The TCE group is unable to be determined.
Check the DPB1*883:01 allele. The TCE group is unable to be determined.
```